### PR TITLE
feat: 支持ctrl+alt点击时，展示父级组件列表

### DIFF
--- a/src/contents/index.ts
+++ b/src/contents/index.ts
@@ -4,39 +4,87 @@ export const config: PlasmoContentScript = {
   matches: ["*://*/*"]
 }
 
+function getSchemeUrl(editor: string, customPath: string, debugSource: any) {
+  const { columnNumber = 0, fileName, lineNumber } = debugSource
+  let url = ""
+  if (editor === "webStorm") {
+    url = `webstorm://open?file=${fileName}&line=${lineNumber}&column=${columnNumber}`
+  } else if (editor === "custom") {
+    url = (
+      customPath ??
+      "vscode://file/${fileName}:${lineNumber}:${columnNumber}"
+    )
+      .replace(/\$\{fileName\}/g, fileName)
+      .replace(/\$\{lineNumber\}/g, lineNumber)
+      .replace(/\$\{columnNumber\}/g, columnNumber)
+  } else {
+    url = `${editor || "vscode"}://file/${fileName}:${lineNumber}:${columnNumber}`
+  }
+  return url
+}
+
 chrome.storage.local.get(["editor"], ({ editor }) => {
   chrome.storage.local.get(["customPath"], ({ customPath }) => {
     window.addEventListener(
       "message",
       (message) => {
         const debugSource = message?.data?.debugSource
-        if (!debugSource) return
-        const { columnNumber = 0, fileName, lineNumber } = debugSource
-        let url = ""
-        if (editor === "webStorm") {
-          url = `webstorm://open?file=${fileName}&line=${lineNumber}&column=${columnNumber}`
-        } else if (editor === "custom") {
-          url = (
-            customPath ??
-            "vscode://file/${fileName}:${lineNumber}:${columnNumber}"
-          )
-            .replace(/\$\{fileName\}/g, fileName)
-            .replace(/\$\{lineNumber\}/g, lineNumber)
-            .replace(/\$\{columnNumber\}/g, columnNumber)
-        } else {
-          url = `${
-            editor || "vscode"
-          }://file/${fileName}:${lineNumber}:${columnNumber}`
+        if (!debugSource || !debugSource.length) return
+        const [firstDebugSource, ...ext] = debugSource
+
+        if (!ext.length) {
+          const url = getSchemeUrl(editor, customPath, firstDebugSource)
+          const iframe = document.createElement("iframe")
+          iframe.style.display = "none"
+          iframe.src = url
+          document.body.appendChild(iframe)
+          setTimeout(() => {
+            iframe.remove()
+          }, 100)
+          return;
         }
-        const iframe = document.createElement("iframe")
-        iframe.style.display = "none"
-        iframe.src = url
-        document.body.appendChild(iframe)
-        setTimeout(() => {
-          iframe.remove()
-        }, 100)
+
+        const list = document.createElement("ul")
+        list.style.position = "fixed"
+        list.style.top = "10px"
+        list.style.right = "10px"
+        list.style.zIndex = "9999999"
+        list.style.backgroundColor = "white"
+        list.style.padding = "10px"
+        list.style.border = "1px solid #ccc"
+        list.style.borderRadius = "5px"
+        list.style.listStyle = "none"
+        list.style.margin = "0"
+        list.style.maxHeight = "400px"
+        list.style.overflow = "auto"
+        list.style.maxWidth = "80%"
+        list.style.boxShadow = "0 0 10px #ccc"
+        list.style.color = "#333"
+        list.style.wordBreak = "break-all"
+
+        debugSource.forEach((item, index) => {
+          const li = document.createElement("li")
+          const a = document.createElement("a")
+          a.href = getSchemeUrl(editor, customPath, item)
+          a.target = "_blank"
+          a.innerText = `${item.fileName}:${item.lineNumber}:${item.columnNumber}`
+          li.appendChild(a)
+          if (index > 0) {
+            li.style.marginTop = "5px"
+            li.style.textIndent = `${index * 10}px`
+          }
+          list.appendChild(li)
+        })
+
+        list.addEventListener("click", (e) => {
+          list.remove()
+        }, {
+          once: true
+        })
+        document.body.appendChild(list)
       },
       false
     )
   })
 })
+

--- a/src/popup.tsx
+++ b/src/popup.tsx
@@ -21,6 +21,7 @@ async function getCurrentTabUrl() {
 function App() {
   const [editor, setEditor] = useState<Editor>("vscode")
   const [customPath, setCustomPath] = useState<string>("")
+  const [maxDeep, setMaxDeep] = useState<number>(3)
 
   useEffect(() => {
     chrome.storage.local.get(["editor"], ({ editor }) => {
@@ -30,6 +31,9 @@ function App() {
       setCustomPath(
         customPath ?? "vscode://file/${fileName}:${lineNumber}:${columnNumber}"
       )
+    })
+    chrome.storage.local.get(["maxDeep"], ({ maxDeep }) => {
+      setMaxDeep(maxDeep ?? 3)
     })
   }, [])
 
@@ -53,9 +57,23 @@ function App() {
     window.close()
   }
 
+  const handleConfirmMaxDeep = async () => {
+    const url = new URL(await getCurrentTabUrl())
+    chrome.tabs.update({
+      url: url.href,
+      active: true
+    })
+    window.close()
+  }
+
   const handleChangeCustomPath = (e: React.ChangeEvent<HTMLInputElement>) => {
     setCustomPath(e.target.value)
     chrome.storage.local.set({ customPath: e.target.value })
+  }
+
+  const handleChangeMaxDeep = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setMaxDeep(Number(e.target.value))
+    chrome.storage.local.set({ maxDeep: Number(e.target.value) })
   }
 
   const handleGoGithub = () => {
@@ -100,6 +118,23 @@ function App() {
             </Button>
           </Box>
         ) : null}
+        <Box fontSize={20} mb={2}>
+          请选择最大深度
+        </Box>
+        <Box display="flex">
+          <Input
+            size={"sm"}
+            value={maxDeep}
+            onChange={handleChangeMaxDeep}
+          />
+          <Button
+            ml={1}
+            size={"sm"}
+            colorScheme="teal"
+            onClick={handleConfirmMaxDeep}>
+            更新
+          </Button>
+        </Box>
         <Link
           fontSize={16}
           mt={1}


### PR DESCRIPTION
解决使用高阶组件封装后，无法找到对应页面位置

同时按住<kbd>Ctrl</kbd> + <kbd>Alt</kbd>点击效果如下

![image](https://github.com/aaamoon/react1s/assets/2452450/ffb691ad-5b97-4995-acf3-320ff22a756b)

